### PR TITLE
PHP 8 updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "deliciousbrains/wp-post-types",
   "description": "WordPress library for registering, reading and writing custom post types.",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Delicious Brains",


### PR DESCRIPTION
- Update valid license from `GPL-2.0+` to `GPL-2.0-or-later`

## Testing instructions

On PHP 8.2+

1. Check for valid `composer.json` with `composer validate`
3. Lint all files with PHP 8 `find . -type f -name "*.php" ! -path "*/vendor/*" -exec php -l {} \; | grep -v "No syntax errors" || true`